### PR TITLE
Closes #1002 (before it also effects Chrome)

### DIFF
--- a/src/PartKeepr/FrontendBundle/Resources/public/js/Components/Widgets/WebcamPanel.js
+++ b/src/PartKeepr/FrontendBundle/Resources/public/js/Components/Widgets/WebcamPanel.js
@@ -49,7 +49,11 @@ Ext.define('PartKeepr.WebcamPanel', {
     },
     handleVideo: function (stream) {
         this.stream = stream;
-        this.video.src = window.URL.createObjectURL(stream);
+        try {
+            this.video.srcObject = stream;
+        } catch (error) {
+            this.video.src = window.URL.createObjectURL(stream);
+        }
     },
     videoError: function () {
         // @todo: Implement video error handler


### PR DESCRIPTION
Do not rely on deprecated the URL.createObjectURL for MediaStream, other than as a fallback for old browsers.

Firefox (62+) have deprecated it, Safari have deprecated it, and Chrome have started the process to deprecate this as well.
I should note that I have not built this code myself and tested it, but the issue #1002 is still present in the demo site and this code here is simply adopted from the developer site of Mozilla.

Sources:
https://bugs.webkit.org/show_bug.cgi?id=167518
https://bugs.chromium.org/p/chromium/issues/detail?id=800767#c28
https://www.fxsitecompat.com/en-CA/docs/2018/url-createobjecturl-no-longer-accepts-mediastream-as-argument/
https://developer.mozilla.org/sv-SE/docs/Web/API/HTMLMediaElement/srcObject#Supporting_fallback_to_the_src_property